### PR TITLE
Moving counters

### DIFF
--- a/DeathCounter/DeathCounter.csproj
+++ b/DeathCounter/DeathCounter.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DeathCounter.cs" />
     <Compile Include="Extensions\FsmUtil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="GlobalSettings.cs" />
     <Compile Include="SaveSettings.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DeathCounter/GlobalSettings.cs
+++ b/DeathCounter/GlobalSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace DeathCounter
+{
+    public class GlobalSettings
+    {
+        public bool ShowCounters = true;
+
+        public bool BesideGeoCount = true;
+
+        public bool UnderGeoCount = false;
+    }
+}


### PR DESCRIPTION
Added option to move the counters below the geo counter, so it doesn't overlap if the geo counter also shows the geo spent
Fixed line 151 where `_settings.TotalDamage` was being applied to `_huddeath`, now correctly sets the value to `_settings.Deaths` on line 242