### PR TITLE
Allow death & hit counters to toggled independently of each other

### DIFF
--- a/DeathCounter/DeathCounter.cs
+++ b/DeathCounter/DeathCounter.cs
@@ -15,7 +15,7 @@ namespace DeathCounter
     {
         public static DeathCounter Instance;
 
-        public override string GetVersion() => "1.5.78-4";
+        public override string GetVersion() => "1.5.78-5";
 
         public static SaveSettings _settings = new SaveSettings();
         public void OnLoadLocal(SaveSettings s)
@@ -73,12 +73,15 @@ namespace DeathCounter
 
             var hudCanvas = GameObject.Find("_GameCameras").FindGameObjectInChildren("HudCamera").FindGameObjectInChildren("Hud Canvas");
             DrawHudDeathAndDamage(prefab, hudCanvas);
-            if (!GlobalSettings.ShowCounters)
+            if (!GlobalSettings.ShowDeathCounter)
+            {
+                _huddeath?.Recycle();
+                _huddeath = null;
+            }
+            if (!GlobalSettings.ShowHitCounter)
             {
                 _huddamage?.Recycle();
-                _huddeath?.Recycle();
                 _huddamage = null;
-                _huddeath = null;
             }
 
             _death = CreateStatObject("death", _settings.Deaths.ToString(), prefab, invCanvas.transform, _deathSprite, new Vector3(6.5f, 0, 0));
@@ -243,10 +246,14 @@ namespace DeathCounter
 
             _huddeath?.Recycle();
             _huddamage?.Recycle();
-            if (!GlobalSettings.ShowCounters)
+            if (!GlobalSettings.ShowDeathCounter)
             {
-                _huddamage = null;
                 _huddeath = null;
+                return;
+            }
+            if (!GlobalSettings.ShowHitCounter)
+            {
+                _huddamage = null;     
                 return;
             }
 

--- a/DeathCounter/GlobalSettings.cs
+++ b/DeathCounter/GlobalSettings.cs
@@ -2,7 +2,9 @@
 {
     public class GlobalSettings
     {
-        public bool ShowCounters = true;
+        public bool ShowDeathCounter = true;
+        
+        public bool ShowHitCounter = true;
 
         public bool BesideGeoCount = true;
 

--- a/DeathCounter/ModMenu.cs
+++ b/DeathCounter/ModMenu.cs
@@ -22,7 +22,7 @@ namespace DeathCounter
                 (opt)=>{DeathCounter.GlobalSettings.ShowDeathCounter=(opt==0); },
                 ()=>DeathCounter.GlobalSettings.ShowDeathCounter? 0:1
                 ),
-                new HorizontalOption("Show Hit Coutner:","Damage will still be tracked in the background",
+                new HorizontalOption("Show Hit Counter:","Damage will still be tracked in the background",
                 new string[]{"True","False"},
                 (opt)=>{DeathCounter.GlobalSettings.ShowHitCounter=(opt==0); },
                 ()=>DeathCounter.GlobalSettings.ShowHitCounter? 0:1

--- a/DeathCounter/ModMenu.cs
+++ b/DeathCounter/ModMenu.cs
@@ -17,10 +17,15 @@ namespace DeathCounter
         {
             return new Menu("Death Counter", new Element[]
             {
-                new HorizontalOption("Show Counters:","Damage and deaths will still be tracked in the background",
+                new HorizontalOption("Show Death Counter:","Deaths will still be tracked in the background",
                 new string[]{"True","False"},
-                (opt)=>{DeathCounter.GlobalSettings.ShowCounters=(opt==0); },
-                ()=>DeathCounter.GlobalSettings.ShowCounters? 0:1
+                (opt)=>{DeathCounter.GlobalSettings.ShowDeathCounter=(opt==0); },
+                ()=>DeathCounter.GlobalSettings.ShowDeathCounter? 0:1
+                ),
+                new HorizontalOption("Show Hit Coutner:","Damage will still be tracked in the background",
+                new string[]{"True","False"},
+                (opt)=>{DeathCounter.GlobalSettings.ShowHitCounter=(opt==0); },
+                ()=>DeathCounter.GlobalSettings.ShowHitCounter? 0:1
                 ),
                 new HorizontalOption("Display Position:",
                 "Toggle where to display the counters",


### PR DESCRIPTION
Full disclaimer, I wasn't actually able to test if this works because Mono refuses to build the project on my system, so feel free to shoot it down if the code is awful (it probably is).

I'm opening this mostly as just a request for this feature, since issues are disabled on the repository. I've been looking for a good death counter mod for a while and this one's almost perfect, but I'd love to be able to display just the death counter on its own.