### PR TITLE
Reposition damage counter correctly on unpause and when settings are changed

### DIFF
--- a/DeathCounter/DeathCounter.cs
+++ b/DeathCounter/DeathCounter.cs
@@ -318,7 +318,7 @@ namespace DeathCounter
                 else if (_huddeath != null)
                 {
                     _huddeath.SetActive(true);
-                    _huddeath.transform.position = origpos + new Vector3(position.Death.X, position.Death.Y);
+                    _huddeath.transform.position = origpos + new Vector3(deathPosition.X, deathPosition.Y);
                 }
 
                 if (!GlobalSettings.ShowHitCounter)
@@ -328,7 +328,7 @@ namespace DeathCounter
                 else if (_huddamage != null)
                 {
                     _huddamage.SetActive(true);
-                    _huddamage.transform.position = origpos + new Vector3(position.Damage.X, position.Damage.Y);
+                    _huddamage.transform.position = origpos + new Vector3(damagePosition.X, damagePosition.Y);
                 }
             }
             catch (Exception e)

--- a/DeathCounter/DeathCounter.cs
+++ b/DeathCounter/DeathCounter.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections;
 using Satchel;
 using EXutil = DeathCounter.Extensions.FsmUtil;
+using System.ComponentModel;
 
 namespace DeathCounter
 {
@@ -66,6 +67,8 @@ namespace DeathCounter
             ModHooks.LanguageGetHook += OnLangGet;
             On.DisplayItemAmount.OnEnable += OnDisplayAmount;
             On.UIManager.UIClosePauseMenu += OnUnpause;
+
+            GlobalSettings.PropertyChanged += GlobalSettings_PropertyChanged;
         }
 
         private void Awake(On.HeroController.orig_Awake orig, HeroController self)
@@ -291,31 +294,42 @@ namespace DeathCounter
         private void OnUnpause(On.UIManager.orig_UIClosePauseMenu origUIClosePauseMenu, UIManager self)
         {
             origUIClosePauseMenu(self);
+            RedrawCounters();
+        }
+
+        private void GlobalSettings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            Log($"{e.PropertyName} changed");
+            RedrawCounters();
+        }
+
+        private void RedrawCounters()
+        {
             try
             {
+                var position = GetPositionOption();
+                var deathPosition = position.Death;
+                var damagePosition = GlobalSettings.ShowDeathCounter ? position.Damage : position.Death;
+
                 if (!GlobalSettings.ShowDeathCounter)
                 {
                     _huddeath?.SetActive(false);
                 }
-                else
+                else if (_huddeath != null)
                 {
-                    _huddeath?.SetActive(true);
+                    _huddeath.SetActive(true);
+                    _huddeath.transform.position = origpos + new Vector3(position.Death.X, position.Death.Y);
                 }
 
                 if (!GlobalSettings.ShowHitCounter)
                 {
                     _huddamage?.SetActive(false);
                 }
-                else
+                else if (_huddamage != null)
                 {
-                    _huddamage?.SetActive(true);
-                }
-
-                var position = GetPositionOption();
-                if (_huddamage != null)
+                    _huddamage.SetActive(true);
                     _huddamage.transform.position = origpos + new Vector3(position.Damage.X, position.Damage.Y);
-                if (_huddeath != null)
-                    _huddeath.transform.position = origpos + new Vector3(position.Death.X, position.Death.Y);
+                }
             }
             catch (Exception e)
             {

--- a/DeathCounter/GlobalSettings.cs
+++ b/DeathCounter/GlobalSettings.cs
@@ -1,21 +1,107 @@
+using System.ComponentModel;
+
 namespace DeathCounter
 {
     public class GlobalSettings
     {
-        public bool ShowDeathCounter = true;
+        private bool _showDeathCounter = true;
+        private bool _showHitCounter = true;
+        private int Position = 0;
 
-        public bool ShowHitCounter = true;
+        public bool ShowDeathCounter
+        {
+            get => _showDeathCounter; 
+            set
+            {
+                if (_showDeathCounter == value)
+                    return;
+                _showDeathCounter = value;
+                OnPropertyChanged(nameof(ShowDeathCounter));
+            }
+        }
 
-        public bool AboveMasks = true;
+        public bool ShowHitCounter
+        {
+            get => _showHitCounter; 
+            set
+            {
+                if (_showHitCounter == value)
+                    return;
+                _showHitCounter = value;
+                OnPropertyChanged(nameof(ShowHitCounter));
+            }
+        }
 
-        public bool BesideGeoCount = false;
+        public bool AboveMasks
+        {
+            get => Position == 0;
+            set
+            {
+                SetPosition(value, 0);
+            }
+        }
 
-        public bool UnderGeoCount = false;
+        public bool BesideGeoCount
+        {
+            get => Position == 1;
+            set
+            {
+                SetPosition(value, 1);
+            }
+        }
 
-        public bool BesideEssenceCount = false;
+        public bool UnderGeoCount
+        {
+            get => Position == 2;
+            set
+            {
+                SetPosition(value, 2);
+            }
+        }
 
-        public bool UnderEssenceCount = false;
+        public bool BesideEssenceCount
+        {
+            get => Position == 3;
+            set
+            {
+                SetPosition(value, 3);
+            }
+        }
 
-        public bool OnLeftEdge = false;
+        public bool UnderEssenceCount
+        {
+            get => Position == 4;
+            set
+            {
+                SetPosition(value, 4);
+            }
+        }
+
+        public bool OnLeftEdge
+        {
+            get => Position == 5;
+            set
+            {
+                SetPosition(value, 5);
+            }
+        }
+
+        private void SetPosition(bool value, int position)
+        {
+            if (value && Position == position)
+                return;
+            if (value)
+            {
+                Position = position;
+                OnPropertyChanged(nameof(Position));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }


### PR DESCRIPTION
Fixed position of damage counter after unpausing when death counter is off
Added listener for when settings are changed while paused to immediately redraw counters